### PR TITLE
Adapte l'interface des filtres de pages : page range à selected pages

### DIFF
--- a/country_by_country/pagefilter/copy_as_is.py
+++ b/country_by_country/pagefilter/copy_as_is.py
@@ -24,6 +24,9 @@
 import shutil
 import tempfile
 
+# External imports
+import pypdf
+
 
 class CopyAsIs:
     """
@@ -40,14 +43,17 @@ class CopyAsIs:
         Writes assets:
             src_pdf: the original pdf filepath
             target_pdf: the temporary target pdf filepath
-            page_range : tuple or None
+            selected_pages : list of selected pages
         """
         filename = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False).name
         shutil.copy(pdf_filepath, filename)
+
+        reader = pypdf.PdfReader(pdf_filepath)
+        n_pages = len(reader.pages)
 
         if assets is not None:
             assets["pagefilter"] = {
                 "src_pdf": pdf_filepath,
                 "target_pdf": filename,
-                "page_range": None,
+                "selected_pages": list(range(n_pages)),
             }


### PR DESCRIPTION
Ce qui est produit dans le dictionnaire `assets` par les filtres de page est trop restrictif.

Pour le moment, c'est forcément une plage contiguie de pages, ce qui ne permet pas de considérer que des tableaux CbCR puissent être distribués sur des pages non contigues et ça interdit aussi d'y placer un algorithme de ML qui n'a aucune raison de filtrer uniquement des plages contigues de pages;

on change donc simplement le type et la sémantique de ce qui est retouné. Ce n'est plus une plage de pages mais une liste des numéros des pages sélectionnées; 