### PR TITLE
Séparation de la sélection des pages et du filtrage des pages

### DIFF
--- a/country_by_country/pagefilter/__init__.py
+++ b/country_by_country/pagefilter/__init__.py
@@ -25,6 +25,7 @@
 # Local imports
 from .copy_as_is import CopyAsIs
 from .from_filename import FromFilename
+from .filter_pages import filter_pages
 
 
 def from_config(config: dict) -> CopyAsIs | FromFilename:

--- a/country_by_country/pagefilter/__init__.py
+++ b/country_by_country/pagefilter/__init__.py
@@ -25,7 +25,6 @@
 # Local imports
 from .copy_as_is import CopyAsIs
 from .from_filename import FromFilename
-from .filter_pages import filter_pages
 
 
 def from_config(config: dict) -> CopyAsIs | FromFilename:

--- a/country_by_country/pagefilter/filter_pages.py
+++ b/country_by_country/pagefilter/filter_pages.py
@@ -22,13 +22,12 @@
 
 # Standard imports
 import tempfile
-from typing import List
 
 # External imports
 import pypdf
 
 
-def filter_pages(pdf_filepath: str, selected_pages: List[int]):
+def filter_pages(pdf_filepath: str, selected_pages: list[int]) -> str:
     """
     Function to extract the selected pages from a source pdf
     It returns the path to the PDF created by keeping only the

--- a/country_by_country/pagefilter/filter_pages.py
+++ b/country_by_country/pagefilter/filter_pages.py
@@ -21,37 +21,26 @@
 # SOFTWARE.
 
 # Standard imports
-import shutil
 import tempfile
+from typing import List
 
 # External imports
 import pypdf
 
 
-class CopyAsIs:
+def filter_pages(pdf_filepath: str, selected_pages: List[int]):
     """
-    Dummy filter just copying the source pdf to a target
-    temporary file
+    Function to extract the selected pages from a source pdf
+    It returns the path to the PDF created by keeping only the
+    selected pages
     """
+    reader = pypdf.PdfReader(pdf_filepath)
+    writer = pypdf.PdfWriter()
 
-    def __init__(self) -> None:
-        pass
+    for pi in selected_pages:
+        writer.add_page(reader.pages[pi])
 
-    def __call__(self, pdf_filepath: str, assets: dict) -> None:
-        """
-        Basically keeps all the pages of the original document
-        Writes assets:
-            src_pdf: the original pdf filepath
-            selected_pages : list of selected pages
-        """
-        filename = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False).name
-        shutil.copy(pdf_filepath, filename)
+    filename = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False).name
+    writer.write(filename)
 
-        reader = pypdf.PdfReader(pdf_filepath)
-        n_pages = len(reader.pages)
-
-        if assets is not None:
-            assets["pagefilter"] = {
-                "src_pdf": pdf_filepath,
-                "selected_pages": list(range(n_pages)),
-            }
+    return filename

--- a/country_by_country/pagefilter/from_filename.py
+++ b/country_by_country/pagefilter/from_filename.py
@@ -21,12 +21,7 @@
 # SOFTWARE.
 
 # Standard imports
-import shutil
-import tempfile
 from pathlib import Path
-
-# External imports
-import pypdf
 
 NUM_PAGE_FIELDS = 2
 
@@ -59,8 +54,6 @@ class FromFilename:
             selected_pages : list of selected pages
         """
 
-        filename = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False).name
-
         # Get the page or page range from the filename
         src_filename = Path(pdf_filepath).name
 
@@ -79,21 +72,8 @@ class FromFilename:
             ):
                 selected_pages = list(range(int(pagefields[0]) - 1, int(pagefields[1])))
 
-        # Extract the selected pages
-        if len(selected_pages) == 0:
-            # If we keep all the page, just copy the pdf
-            shutil.copy(pdf_filepath, filename)
-        else:
-            reader = pypdf.PdfReader(pdf_filepath)
-            writer = pypdf.PdfWriter()
-
-            for pi in selected_pages:
-                writer.add_page(reader.pages[pi])
-            writer.write(filename)
-
         if assets is not None:
             assets["pagefilter"] = {
                 "src_pdf": pdf_filepath,
-                "target_pdf": filename,
                 "selected_pages": selected_pages,
             }

--- a/country_by_country/processor.py
+++ b/country_by_country/processor.py
@@ -50,7 +50,12 @@ class ReportProcessor:
         # Filtering the pages
         self.page_filter(pdf_filepath, assets)
 
-        pdf_to_process = assets["pagefilter"]["target_pdf"]
+        # Now that we identified the pages to be extracted, we extract them
+        # Note, in a GUI, we could ask the user to the change the content of
+        # assets["pagefilter"]["selected_pages"] before selecting the pages
+        pdf_to_process = pagefilter.filter_pages(
+            pdf_filepath, assets["pagefilter"]["selected_pages"]
+        )
 
         # Process the selected pages to detect the tables and extract
         # their contents

--- a/country_by_country/processor.py
+++ b/country_by_country/processor.py
@@ -54,7 +54,8 @@ class ReportProcessor:
         # Note, in a GUI, we could ask the user to the change the content of
         # assets["pagefilter"]["selected_pages"] before selecting the pages
         pdf_to_process = pagefilter.filter_pages(
-            pdf_filepath, assets["pagefilter"]["selected_pages"]
+            pdf_filepath,
+            assets["pagefilter"]["selected_pages"],
         )
 
         # Process the selected pages to detect the tables and extract


### PR DESCRIPTION
Dans la version actuelle du code, ce sont les filtres qui s'occupent également de la production du PDF filtré;

Ca ne permet pas d'injecter un humain dans la boucle pour raffiner les pages sélectionnées;

Cette PR sépare le filtrage du PDF de l'opération de sélection des pages. Une interface graphique pourra alors permettre de demander à un utilisateur de raffiner la sélection des pages. 

L'impact se voit sur la méthode  ReportProcessor::process. 