### PR TITLE
Ajout de tests unitaires pour camelot et unstructured

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install poppler (required by pdf2image/unstructured)
         run: sudo apt install -y poppler-utils
       - name: Install tesseract (required by unstructured)
-        run: sudo apt install -y tesseract
+        run: sudo apt install -y tesseract-ocr
       - name: Install tox
         run: pip install tox
       - name: Run tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,8 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install poppler (required by pdf2image/unstructured)
         run: sudo apt install -y poppler-utils
+      - name: Install tesseract (required by unstructured)
+        run: sudo apt install -y tesseract
       - name: Install tox
         run: pip install tox
       - name: Run tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+      - name: Install poppler (required by pdf2image/unstructured)
+        run: sudo apt install -y poppler-utils
       - name: Install tox
         run: pip install tox
       - name: Run tox

--- a/test/data/unstructured_yolox_Acciona_2020_CbCR_1.csv
+++ b/test/data/unstructured_yolox_Acciona_2020_CbCR_1.csv
@@ -1,0 +1,13 @@
+Tax jurisdiction,Total sales (M€),EBT (M€),Corporate Income Tax accrued (M€),Corporate Income Tax paid on a cash basis (M€),Employees at the close of 2020,Grants (M€),Footnote explaining effective rate due,Footnote explaining effective rate paid
+Spain,2673,367,51,-0.7,20860,48.0,1.0,2.0
+Germany,12,75,-8,-1.0,428,0.0,1.0,2.0
+Mexico,238,54,19,71.0,1978,0.0,5.8,9.0
+Australia,881,33,13,0.0,1704,0.0,45.0,10.0
+Poland,335,19,4,14.0,1523,0.0,4.0,9.0
+Saudi Arabia,329,10,6,6.6,131,0.0,4.0,4.0
+Portugal,152,9,7,5.2,2015,0.01,7.0,11.0
+Brazil,44,-8,-16,0.2,390,0.0,3.0,2.0
+USA,7),-4),-6,0.0,184,13.0,7.0,2.1
+Canada,327,-44,-1,1.0,1379,0.0,7.0,2.0
+Others,1409,35,27,24.8,7763,0.3,,
+Total,6472,508,97,44.5,38355,6.4,,

--- a/test/test_camelot.py
+++ b/test/test_camelot.py
@@ -1,0 +1,98 @@
+# MIT License
+#
+# Copyright (c) 2024 dataforgood
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Local imports
+from country_by_country import img_table_extraction
+
+
+def test_camelot() -> None:
+    flavor = "stream"
+    config = {"type": "Camelot", "params": {"flavor": flavor}}
+    table_extractor = img_table_extraction.from_config(config)
+
+    src_path = "./test/data/Acciona_2020_CbCR_1.pdf"
+    assets = {"text_table_extractors": {}}
+    table_extractor(src_path, assets)
+
+    ntables = assets["text_table_extractors"][f"camelot_{flavor}"]["ntables"]
+    tables = assets["text_table_extractors"][f"camelot_{flavor}"]["tables"]
+
+    # As of 03/2024, camelot detects 4 tables
+    assert ntables == 4
+
+    # To get the expected result :
+    # python -m pytest -s
+    # cbcr_table = tables[1]
+    # column_idx = 3
+    # print(cbcr_table[column_idx].tolist())
+
+    expected_c0 = [
+        "",
+        "",
+        "",
+        "",
+        "Spain",
+        "Germany",
+        "",
+        "Mexico",
+        "",
+        "Australia",
+        "Poland",
+        "",
+        "Saudi Arabia",
+        "",
+        "Portugal",
+        "Brazil",
+        "USA",
+        "",
+        "Canada",
+        "Others",
+        "Total",
+        "",
+    ]
+
+    expected_c3 = [
+        "Tax accrued (M€)",
+        "",
+        "",
+        "",
+        "51",
+        "-8",
+        "",
+        "19",
+        "",
+        "13",
+        "4",
+        "",
+        "6",
+        "",
+        "7",
+        "-16",
+        "-6",
+        "",
+        "-0.1",
+        "27",
+        "97",
+        "",
+    ]
+    assert tables[1][0].tolist() == expected_c0
+    assert tables[1][3].tolist() == expected_c3

--- a/test/test_camelot.py
+++ b/test/test_camelot.py
@@ -23,6 +23,8 @@
 # Local imports
 from country_by_country import img_table_extraction
 
+NTABLES_DETECTED_ACCIONA = 4
+
 
 def test_camelot() -> None:
     flavor = "stream"
@@ -37,13 +39,13 @@ def test_camelot() -> None:
     tables = assets["text_table_extractors"][f"camelot_{flavor}"]["tables"]
 
     # As of 03/2024, camelot detects 4 tables
-    assert ntables == 4
+    assert ntables == NTABLES_DETECTED_ACCIONA
 
     # To get the expected result :
     # python -m pytest -s
-    # cbcr_table = tables[1]
-    # column_idx = 3
-    # print(cbcr_table[column_idx].tolist())
+    # >>> cbcr_table = tables[1]
+    # >>> column_idx = 3
+    # >>> print(cbcr_table[column_idx].tolist())
 
     expected_c0 = [
         "",

--- a/test/test_pagefilter.py
+++ b/test/test_pagefilter.py
@@ -40,7 +40,7 @@ def test_copy_as_is() -> None:
     assert assets["pagefilter"]["selected_pages"] == list(range(11))
 
 
-def test_filter_pages() -> None:
+def test_from_filemane() -> None:
     config = {"type": "FromFilename"}
     myfilter = pagefilter.from_config(config)
 

--- a/test/test_pagefilter.py
+++ b/test/test_pagefilter.py
@@ -20,7 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# External imports
+import pypdf
+
+# Local imports
 from country_by_country import pagefilter
+from country_by_country.pagefilter.filter_pages import filter_pages
 
 
 def test_copy_as_is() -> None:
@@ -75,3 +80,15 @@ def test_rf_classifier() -> None:
     myfilter(src_path, assets)
     assert assets["pagefilter"]["src_pdf"] == src_path
     assert assets["pagefilter"]["selected_pages"] == [6, 7]
+
+
+def test_filter_pages() -> None:
+    src_path = "./test/data/Acciona_2020_CbCR_1.pdf"
+    selected_pages = [0]
+    out_pdf = filter_pages(src_path, selected_pages)
+
+    # This test does not work even if we just copy
+    # all the pages from the source pdf
+
+    reader = pypdf.PdfReader(out_pdf)
+    assert len(reader.pages) == len(selected_pages)

--- a/test/test_unstructured.py
+++ b/test/test_unstructured.py
@@ -56,7 +56,4 @@ def test_unstructured_yolox() -> None:
         "./test/data/unstructured_yolox_Acciona_2020_CbCR_1.csv",
     )
 
-    print(table)
-    print(expected_table)
-
     assert_frame_equal(table, expected_table)

--- a/test/test_unstructured.py
+++ b/test/test_unstructured.py
@@ -22,6 +22,7 @@
 
 # External imports
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 # Local imports
 from country_by_country import img_table_extraction
@@ -55,4 +56,7 @@ def test_unstructured_yolox() -> None:
         "./test/data/unstructured_yolox_Acciona_2020_CbCR_1.csv",
     )
 
-    assert table == expected_table
+    print(table)
+    print(expected_table)
+
+    assert_frame_equal(table, expected_table)

--- a/test/test_unstructured.py
+++ b/test/test_unstructured.py
@@ -1,0 +1,122 @@
+# MIT License
+#
+# Copyright (c) 2024 dataforgood
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# External imports
+import numpy as np
+
+# Local imports
+from country_by_country import img_table_extraction
+
+
+def test_unstructured_yolox() -> None:
+    config = {
+        "type": "Unstructured",
+        "params": {"pdf_image_dpi": 300, "hi_res_model_name": "yolox"},
+    }
+    table_extractor = img_table_extraction.from_config(config)
+
+    src_path = "./test/data/Acciona_2020_CbCR_1.pdf"
+    assets = {"img_table_extractors": {}}
+    table_extractor(src_path, assets)
+
+    ntables = assets["img_table_extractors"]["unstructured"]["ntables"]
+    tables = assets["img_table_extractors"]["unstructured"]["tables"]
+
+    # To get the expected result :
+    # python -m pytest -s
+    # cbcr_table = tables[1]
+    # column_idx = 3
+    # print(cbcr_table[column_idx].tolist())
+
+    # As of 03/2024, unstructured yolox detects 1 table
+    assert ntables == 1
+
+    # The detection of the table is perfect
+    table = tables[0][0]
+
+    assert table.shape == (12, 9)
+
+    # for column_idx in range(9):
+    #     print(f"expected_c{column_idx} = {table[\"columns[column_idx]\"].tolist()}")
+    expected_columns = [
+        "Tax jurisdiction",
+        "Total sales (M€)",
+        "EBT (M€)",
+        "Corporate Income Tax accrued (M€)",
+        "Corporate Income Tax paid on a cash basis (M€)",
+        "Employees at the close of 2020",
+        "Grants (M€)",
+        "Footnote explaining effective rate due",
+        "Footnote explaining effective rate paid",
+    ]
+
+    assert list(table.columns) == expected_columns
+    expected_c0 = [
+        "Spain",
+        "Germany",
+        "Mexico",
+        "Australia",
+        "Poland",
+        "Saudi Arabia",
+        "Portugal",
+        "Brazil",
+        "USA",
+        "Canada",
+        "Others",
+        "Total",
+    ]
+
+    # assert table[] == expected_columns
+    expected_c1 = [
+        "2673",
+        "12",
+        "238",
+        "881",
+        "335",
+        "329",
+        "152",
+        "44",
+        "7)",
+        "327",
+        "1409",
+        "6472",
+    ]
+    expected_c2 = [
+        "367",
+        "75",
+        "54",
+        "33",
+        "19",
+        "10",
+        "9",
+        "-8",
+        "-4)",
+        "-44",
+        "35",
+        "508",
+    ]
+    expected_c3 = [51, -8, 19, 13, 4, 6, 7, -16, -6, -1, 27, 97]
+    expected_c4 = [-0.7, -1.0, 71.0, 0.0, 14.0, 6.6, 5.2, 0.2, 0.0, 1.0, 24.8, 44.5]
+    expected_c5 = [20860, 428, 1978, 1704, 1523, 131, 2015, 390, 184, 1379, 7763, 38355]
+    expected_c6 = [48.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 13.0, 0.0, 0.3, 6.4]
+    expected_c7 = [1.0, 1.0, 5.8, 45.0, 4.0, 4.0, 7.0, 3.0, 7.0, 7.0, np.nan, np.nan]
+    expected_c8 = [2.0, 2.0, 9.0, 10.0, 9.0, 4.0, 11.0, 2.0, 2.1, 2.0, np.nan, np.nan]

--- a/test/test_unstructured.py
+++ b/test/test_unstructured.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 # External imports
-import numpy as np
 import pandas as pd
 
 # Local imports
@@ -50,10 +49,10 @@ def test_unstructured_yolox() -> None:
 
     # To get the expected result :
     # python -m pytest -s
-    # table.to_csv("/tmp/table.csv", index=False)
+    # >> table.to_csv("/tmp/table.csv", index=False)
 
     expected_table = pd.read_csv(
-        "./test/data/unstructured_yolox_Acciona_2020_CbCR_1.csv"
+        "./test/data/unstructured_yolox_Acciona_2020_CbCR_1.csv",
     )
 
     assert table == expected_table

--- a/test/test_unstructured.py
+++ b/test/test_unstructured.py
@@ -22,6 +22,7 @@
 
 # External imports
 import numpy as np
+import pandas as pd
 
 # Local imports
 from country_by_country import img_table_extraction
@@ -41,82 +42,18 @@ def test_unstructured_yolox() -> None:
     ntables = assets["img_table_extractors"]["unstructured"]["ntables"]
     tables = assets["img_table_extractors"]["unstructured"]["tables"]
 
-    # To get the expected result :
-    # python -m pytest -s
-    # cbcr_table = tables[1]
-    # column_idx = 3
-    # print(cbcr_table[column_idx].tolist())
-
     # As of 03/2024, unstructured yolox detects 1 table
     assert ntables == 1
 
     # The detection of the table is perfect
     table = tables[0][0]
 
-    assert table.shape == (12, 9)
+    # To get the expected result :
+    # python -m pytest -s
+    # table.to_csv("/tmp/table.csv", index=False)
 
-    # for column_idx in range(9):
-    #     print(f"expected_c{column_idx} = {table[\"columns[column_idx]\"].tolist()}")
-    expected_columns = [
-        "Tax jurisdiction",
-        "Total sales (M€)",
-        "EBT (M€)",
-        "Corporate Income Tax accrued (M€)",
-        "Corporate Income Tax paid on a cash basis (M€)",
-        "Employees at the close of 2020",
-        "Grants (M€)",
-        "Footnote explaining effective rate due",
-        "Footnote explaining effective rate paid",
-    ]
+    expected_table = pd.read_csv(
+        "./test/data/unstructured_yolox_Acciona_2020_CbCR_1.csv"
+    )
 
-    assert list(table.columns) == expected_columns
-    expected_c0 = [
-        "Spain",
-        "Germany",
-        "Mexico",
-        "Australia",
-        "Poland",
-        "Saudi Arabia",
-        "Portugal",
-        "Brazil",
-        "USA",
-        "Canada",
-        "Others",
-        "Total",
-    ]
-
-    # assert table[] == expected_columns
-    expected_c1 = [
-        "2673",
-        "12",
-        "238",
-        "881",
-        "335",
-        "329",
-        "152",
-        "44",
-        "7)",
-        "327",
-        "1409",
-        "6472",
-    ]
-    expected_c2 = [
-        "367",
-        "75",
-        "54",
-        "33",
-        "19",
-        "10",
-        "9",
-        "-8",
-        "-4)",
-        "-44",
-        "35",
-        "508",
-    ]
-    expected_c3 = [51, -8, 19, 13, 4, 6, 7, -16, -6, -1, 27, 97]
-    expected_c4 = [-0.7, -1.0, 71.0, 0.0, 14.0, 6.6, 5.2, 0.2, 0.0, 1.0, 24.8, 44.5]
-    expected_c5 = [20860, 428, 1978, 1704, 1523, 131, 2015, 390, 184, 1379, 7763, 38355]
-    expected_c6 = [48.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 13.0, 0.0, 0.3, 6.4]
-    expected_c7 = [1.0, 1.0, 5.8, 45.0, 4.0, 4.0, 7.0, 3.0, 7.0, 7.0, np.nan, np.nan]
-    expected_c8 = [2.0, 2.0, 9.0, 10.0, 9.0, 4.0, 11.0, 2.0, 2.1, 2.0, np.nan, np.nan]
+    assert table == expected_table


### PR DESCRIPTION
Dans cette PR, on ajoute des tests pour vérifier la stabilité de l'extraction par camelot et unstructured.

En pratique, il y a 2 logiques :
- pour camelot, dont les résultats sont moins bons que unstructured, le code vérifie le nombre de tables extraites et le contenu de deux colonnes de l'une des tables
-  pour unstructured, comme l'extraction est presque parfaite sur Acciona, on vérifie tout le contenu extrait en comparant l'extraction avec la vérité 

Sur Acciona, l'extraction est presque parfaite avec unstructured mais pas tout à fait. Souvent, des décimales manquantes. Il y a quelques erreurs comme : -1/-0.1, 48/4.8 , 45/4.5 . Des parenthèses aussi sont parfois détectées au lieu de "1" : 7) / 71 , -4) / -41 . Mais le test compare avec ce qui est extrait avec la version actuelle de unstructured. Peut être qu'une version ultérieure (peut être juste de paramétrage de dpi dans l'export en image?) conduira à une meilleure extraction. Cela veut dire qu'un échec à ce test pourrait être un signe que la nouvelle version de unstructured fait mieux !

D'ailleurs, la comparaison de pandas `assert_frame_equal` affiche, lorsque le test échoue, les colonnes ou lignes sur lesquelles les valeurs diffèrent.