### PR TITLE
Exécution partielle du pipeline

### DIFF
--- a/configs/v0.yaml
+++ b/configs/v0.yaml
@@ -16,3 +16,5 @@ table_extraction:
         pdf_image_dpi: 300
         hi_res_model_name: "yolox"
 #    - type: LLamaParse
+
+# table_cleaning:

--- a/country_by_country/processor.py
+++ b/country_by_country/processor.py
@@ -34,16 +34,23 @@ class ReportProcessor:
         self.page_filter = pagefilter.from_config(config["pagefilter"])
 
         # Table extraction from images
-        img_table_extractors = config["table_extraction"]["img"]
-        self.img_table_extractors = [
-            img_table_extraction.from_config(name) for name in img_table_extractors
-        ]
+        self.img_table_extractors = []
+        self.table_cleaners = []
 
-        # Table cleaning & reformatting
-        table_cleaners = config["table_cleaning"]
-        self.table_cleaners = [
-            table_cleaning.from_config(name) for name in table_cleaners
-        ]
+        if "table_extraction" in config:
+            img_table_extractors = config["table_extraction"]["img"]
+            self.img_table_extractors = [
+                img_table_extraction.from_config(name) for name in img_table_extractors
+            ]
+
+            # Table cleaning & reformatting
+            # We can do this step only if we had table extraction algorithms
+            # otherwise, the assets will not be available
+            if "table_cleaning" in config:
+                table_cleaners = config["table_cleaning"]
+                self.table_cleaners = [
+                    table_cleaning.from_config(name) for name in table_cleaners
+                ]
 
     def process(self, pdf_filepath: str) -> dict:
         logging.info(f"Processing {pdf_filepath}")


### PR DESCRIPTION
Cette petite PR permet de court-circuiter des parties du pipeline.

Par exemple, avec la même base de code `country_by_country`, on peut se limiter à :

- n'exécuter que le filtrage des pages si les clé  `table_extraction` et `table_cleaning` sont absents du fichier de config
- n'exécuter que le filtrage + l'extraction des tables si la clé `table_cleaning` n'est pas présente

Cela permet de n'appliquer que certaines parties du pipeline.
