### PR TITLE
Table cleaning stage compatible avec plusieurs tables extraction stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 # Precommit hooks: ruff cache
 .ruff_cache
+.DS_Store

--- a/country_by_country/__main__.py
+++ b/country_by_country/__main__.py
@@ -29,17 +29,22 @@ from pathlib import Path
 import yaml
 
 # Local imports
+from dotenv import load_dotenv
 from country_by_country import processor
 
 NUM_CLI_ARGS = 3
 
 
 def process_report(config: dict, pdf_filepath: str) -> None:
+     # Loading API keys from .env file
+    load_dotenv()
+
     proc = processor.ReportProcessor(config)
     return proc.process(pdf_filepath)
 
 
 if __name__ == "__main__":
+
     logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
 
     if len(sys.argv) != NUM_CLI_ARGS:

--- a/country_by_country/__main__.py
+++ b/country_by_country/__main__.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         logging.error("Usage : python -m country_by_country config.yaml report.pdf")
         sys.exit(-1)
 
-    logging.info(f"Loading {sys.argv[1]}")
+    logging.info(f"\nLoading {sys.argv[1]}")
     with Path(sys.argv[1]).open() as fh:
         config = yaml.safe_load(fh)
 

--- a/country_by_country/__main__.py
+++ b/country_by_country/__main__.py
@@ -30,13 +30,14 @@ import yaml
 
 # Local imports
 from dotenv import load_dotenv
+
 from country_by_country import processor
 
 NUM_CLI_ARGS = 3
 
 
 def process_report(config: dict, pdf_filepath: str) -> None:
-     # Loading API keys from .env file
+    # Loading API keys from .env file
     load_dotenv()
 
     proc = processor.ReportProcessor(config)

--- a/country_by_country/img_table_extraction/camelot_extractor.py
+++ b/country_by_country/img_table_extraction/camelot_extractor.py
@@ -57,4 +57,3 @@ class Camelot:
         }
 
         return new_asset
-    

--- a/country_by_country/img_table_extraction/camelot_extractor.py
+++ b/country_by_country/img_table_extraction/camelot_extractor.py
@@ -22,6 +22,7 @@
 
 # Standard imports
 import logging
+import uuid
 
 # External imports
 import camelot
@@ -30,25 +31,30 @@ import camelot
 class Camelot:
     def __init__(self, flavor: str) -> None:
         self.flavor = flavor
+        self.type = "camelot"
 
-    def __call__(self, pdf_filepath: str, assets: dict) -> None:
+    def __call__(self, pdf_filepath: str) -> dict:
         """
         Writes assets:
             ntables: the number of detected tables
             tables: a list of pandas dataframe of the parsed tables
         """
+        logging.info("\nKicking off extraction stage...")
+        logging.info(f"Extraction type: {self.type}, with params: {self.flavor}")
+
         tables = camelot.read_pdf(pdf_filepath, flavor=self.flavor)
 
         # Write the parsed tables into the assets
         tables_list = [t.df for t in tables]
-        key_assets = f"camelot_{self.flavor}"
-        if key_assets in assets["text_table_extractors"]:
-            logging.warning(
-                f">> The key {key_assets} already exists"
-                f" in the assets dictionary. I will overwrite its content",
-            )
 
-        assets["text_table_extractors"][key_assets] = {
+        # Create asset
+        new_asset = {
+            "id": uuid.uuid4(),
+            "type": "camelot",
+            "params": {"flavor": self.flavor},
             "ntables": len(tables_list),
             "tables": tables_list,
         }
+
+        return new_asset
+    

--- a/country_by_country/img_table_extraction/camelot_extractor.py
+++ b/country_by_country/img_table_extraction/camelot_extractor.py
@@ -35,8 +35,7 @@ class Camelot:
 
     def __call__(self, pdf_filepath: str) -> dict:
         """
-        Writes assets:
-            ntables: the number of detected tables
+        Returns asset that contain:
             tables: a list of pandas dataframe of the parsed tables
         """
         logging.info("\nKicking off extraction stage...")
@@ -52,7 +51,6 @@ class Camelot:
             "id": uuid.uuid4(),
             "type": "camelot",
             "params": {"flavor": self.flavor},
-            "ntables": len(tables_list),
             "tables": tables_list,
         }
 

--- a/country_by_country/img_table_extraction/llama_parse_extractor.py
+++ b/country_by_country/img_table_extraction/llama_parse_extractor.py
@@ -27,7 +27,6 @@ import uuid
 # External imports
 import nest_asyncio
 import pandas as pd
-from dotenv import load_dotenv
 from llama_parse import LlamaParse
 
 
@@ -43,8 +42,6 @@ class LlamaParseExtractor:
         self.kwargs = kwargs
         self.type = "llama_parse"
 
-        # Load LLAMA_CLOUD_API_KEY from .env file
-        load_dotenv()
         # llama-parse is async-first
         nest_asyncio.apply()
 

--- a/country_by_country/img_table_extraction/llama_parse_extractor.py
+++ b/country_by_country/img_table_extraction/llama_parse_extractor.py
@@ -63,7 +63,6 @@ class LlamaParseExtractor:
             "id": uuid.uuid4(),
             "type": self.type,
             "params": self.kwargs,
-            "ntables": len(tables_list),
             "tables": tables_list,
         }
 

--- a/country_by_country/img_table_extraction/llama_parse_extractor.py
+++ b/country_by_country/img_table_extraction/llama_parse_extractor.py
@@ -21,9 +21,10 @@
 # SOFTWARE.
 
 # Standard imports
+import logging
+import uuid
 
 # External imports
-
 import nest_asyncio
 import pandas as pd
 from dotenv import load_dotenv
@@ -40,13 +41,17 @@ class LlamaParseExtractor:
         You are free to define any parameter LlamaParse recognizes
         """
         self.kwargs = kwargs
+        self.type = "llama_parse"
 
         # Load LLAMA_CLOUD_API_KEY from .env file
         load_dotenv()
         # llama-parse is async-first
         nest_asyncio.apply()
 
-    def __call__(self, pdf_filepath: str, assets: dict) -> None:
+    def __call__(self, pdf_filepath: str) -> dict:
+        logging.info("\nKicking off extraction stage...")
+        logging.info(f"Extraction type: {self.type}, with params: {self.kwargs}")
+
         json_objs = LlamaParse(**self.kwargs).get_json_result(pdf_filepath)
 
         tables_list = []
@@ -56,7 +61,13 @@ class LlamaParseExtractor:
                     df = pd.DataFrame(item["rows"][1:], columns=item["rows"][0])
                     tables_list.append(df)
 
-        assets["img_table_extractors"]["llama_parse"] = {
+        # Create asset
+        new_asset = {
+            "id": uuid.uuid4(),
+            "type": self.type,
+            "params": self.kwargs,
             "ntables": len(tables_list),
             "tables": tables_list,
         }
+
+        return new_asset

--- a/country_by_country/img_table_extraction/unstructured.py
+++ b/country_by_country/img_table_extraction/unstructured.py
@@ -21,6 +21,8 @@
 # SOFTWARE.
 
 # Standard imports
+import logging
+import uuid
 
 # External imports
 from io import StringIO
@@ -30,7 +32,7 @@ from unstructured.partition.pdf import partition_pdf
 
 
 class Unstructured:
-    def __init__(self, **kwargs: dict) -> None:
+    def __init__(self, **kwargs: dict) -> dict:
         """
         Builds a pdf page parser, looking for tables using
         the unstructured library.
@@ -39,8 +41,12 @@ class Unstructured:
         You are free to define any parameter partition_pdf recognizes
         """
         self.kwargs = kwargs
+        self.type = "unstructured"
 
-    def __call__(self, pdf_filepath: str, assets: dict) -> None:
+    def __call__(self, pdf_filepath: str) -> dict:
+        logging.info("\nKicking off extraction stage...")
+        logging.info(f"Extraction type: {self.type}, with params: {self.kwargs}")
+
         elements = partition_pdf(
             pdf_filepath,
             infer_table_structure=True,
@@ -52,7 +58,13 @@ class Unstructured:
             pd.read_html(StringIO(t.metadata.text_as_html))[0] for t in tables_list
         ]
 
-        assets["img_table_extractors"]["unstructured"] = {
+        # Create asset
+        new_asset = {
+            "id": uuid.uuid4(),
+            "type": "unstructured",
+            "params": self.kwargs,
             "ntables": len(tables_list),
             "tables": tables_list,
         }
+
+        return new_asset

--- a/country_by_country/img_table_extraction/unstructured.py
+++ b/country_by_country/img_table_extraction/unstructured.py
@@ -63,7 +63,6 @@ class Unstructured:
             "id": uuid.uuid4(),
             "type": "unstructured",
             "params": self.kwargs,
-            "ntables": len(tables_list),
             "tables": tables_list,
         }
 

--- a/country_by_country/processor.py
+++ b/country_by_country/processor.py
@@ -50,12 +50,12 @@ class ReportProcessor:
 
         assets = {
             "pagefilter": {},
-            "text_table_extractors": {},
-            "img_table_extractors": {},
-            "table_cleaners": {},
+            "text_table_extractors": [],
+            "img_table_extractors": [],
+            "table_cleaners": [],
         }
 
-        # Filtering the pages
+        # Identifying the pages to extract
         self.page_filter(pdf_filepath, assets)
 
         # Now that we identified the pages to be extracted, we extract them
@@ -69,10 +69,13 @@ class ReportProcessor:
         # Process the selected pages to detect the tables and extract
         # their contents
         for img_table_extractor in self.img_table_extractors:
-            img_table_extractor(pdf_to_process, assets)
+            new_asset = img_table_extractor(pdf_to_process)
+            assets["img_table_extractors"].append(new_asset)
 
         # Give the parsed content to the cleaner stage for getting organized data
         for table_cleaner in self.table_cleaners:
-            table_cleaner(assets)
+            for asset in assets["img_table_extractors"]:
+                new_asset = table_cleaner(asset)
+                assets["table_cleaners"].append(new_asset)
 
         return assets

--- a/country_by_country/table_cleaning/llm_cleaner.py
+++ b/country_by_country/table_cleaning/llm_cleaner.py
@@ -101,7 +101,7 @@ class LLMCleaner:
         responses1 = chain1.batch(html_tables, {"max_concurrency": 4})
 
         # Extract country lists from responses
-        country_lists = [resp["country_names"] + ["Others"] for resp in responses1]
+        country_lists = [resp["country_names"] for resp in responses1]
 
         # ---------- CHAIN 2/2 - Pull financial data for each country ----------
         logging.info("Starting chain 2/2: extracting financial data from tables")

--- a/country_by_country/table_cleaning/llm_cleaner.py
+++ b/country_by_country/table_cleaning/llm_cleaner.py
@@ -53,7 +53,7 @@ class LLMCleaner:
         logging.info("\nKicking off cleaning stage...")
         logging.info(f"Cleaning type: {self.type}, with params: {self.kwargs}")
         logging.info(
-            f"Input extraction type: {asset['type']}, with params: {asset['params']}"
+            f"Input extraction type: {asset['type']}, with params: {asset['params']}",
         )
 
         # Extract tables from previous stage

--- a/country_by_country/table_cleaning/llm_cleaner.py
+++ b/country_by_country/table_cleaning/llm_cleaner.py
@@ -27,7 +27,6 @@ import uuid
 import pandas as pd
 
 # External imports
-from dotenv import load_dotenv
 from IPython.display import display
 from langchain.prompts import PromptTemplate
 from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
@@ -49,9 +48,6 @@ class LLMCleaner:
         self.kwargs = kwargs
         self.type = "llm_cleaner"
         self.openai_model = self.kwargs["openai_model"]
-
-        # Load OPENAI and LANGCHAIN API keys from .env file
-        load_dotenv()
 
     def __call__(self, asset: dict) -> dict:
         logging.info("\nKicking off cleaning stage...")

--- a/test/test_camelot.py
+++ b/test/test_camelot.py
@@ -32,11 +32,10 @@ def test_camelot() -> None:
     table_extractor = img_table_extraction.from_config(config)
 
     src_path = "./test/data/Acciona_2020_CbCR_1.pdf"
-    assets = {"text_table_extractors": {}}
-    table_extractor(src_path, assets)
+    asset = table_extractor(src_path)
 
-    ntables = assets["text_table_extractors"][f"camelot_{flavor}"]["ntables"]
-    tables = assets["text_table_extractors"][f"camelot_{flavor}"]["tables"]
+    ntables = asset["ntables"]
+    tables = asset["tables"]
 
     # As of 03/2024, camelot detects 4 tables
     assert ntables == NTABLES_DETECTED_ACCIONA

--- a/test/test_camelot.py
+++ b/test/test_camelot.py
@@ -34,11 +34,10 @@ def test_camelot() -> None:
     src_path = "./test/data/Acciona_2020_CbCR_1.pdf"
     asset = table_extractor(src_path)
 
-    ntables = asset["ntables"]
     tables = asset["tables"]
 
     # As of 03/2024, camelot detects 4 tables
-    assert ntables == NTABLES_DETECTED_ACCIONA
+    assert len(tables) == NTABLES_DETECTED_ACCIONA
 
     # To get the expected result :
     # python -m pytest -s

--- a/test/test_unstructured.py
+++ b/test/test_unstructured.py
@@ -36,11 +36,10 @@ def test_unstructured_yolox() -> None:
     table_extractor = img_table_extraction.from_config(config)
 
     src_path = "./test/data/Acciona_2020_CbCR_1.pdf"
-    assets = {"img_table_extractors": {}}
-    table_extractor(src_path, assets)
+    asset = table_extractor(src_path)
 
-    ntables = assets["img_table_extractors"]["unstructured"]["ntables"]
-    tables = assets["img_table_extractors"]["unstructured"]["tables"]
+    ntables = asset["ntables"]
+    tables = asset["tables"]
 
     # As of 03/2024, unstructured yolox detects 1 table
     assert ntables == 1

--- a/test/test_unstructured.py
+++ b/test/test_unstructured.py
@@ -38,11 +38,10 @@ def test_unstructured_yolox() -> None:
     src_path = "./test/data/Acciona_2020_CbCR_1.pdf"
     asset = table_extractor(src_path)
 
-    ntables = asset["ntables"]
     tables = asset["tables"]
 
     # As of 03/2024, unstructured yolox detects 1 table
-    assert ntables == 1
+    assert len(tables) == 1
 
     # The detection of the table is perfect
     table = tables[0]


### PR DESCRIPTION
Cette PR adresse le TODO dans https://github.com/dataforgoodfr/12_taxobservatory/pull/14:
> Currently only works if Unstructured is used in the table extraction stage (need to fix, see [TODO](https://github.com/dataforgoodfr/12_taxobservatory/blob/688f746460c5170390071f19dbe698650a4dc5ac/country_by_country/table_cleaning/llm_cleaner.py#L56) in code)

Changements proposés:
* L'objet `assets` contient des arrays (voir `processor.py`)
* Les fonctions d'extraction et de cleaning ne reçoivent plus l'objet haut niveau `assets` en argument, mais uniquement ce qui est nécessaire pour effectuer leur traitement, c'est à dire `pdf_filepath` pour l' extraction ou un asset d'extraction pour le cleaning
* Les fonctions d'extraction et de cleaning retournent l'asset créé, c'est à dire une ou des tables avec la metadata associée, qui sera ensuite ajouté à l'objet `assets` par `processor.py`
* Chaque asset inclut un identifiant pour permettre la traçabilité, notamment entre extraction et cleaning

Changements après review:
* Env chargé dans main
* Paramètre `ntables` supprimé (peut être calculé dynamiquement)

J'en ai profité pour ajouter un peu de logging pour pouvoir suivre plus facilement les différentes itérations de traitement.