### PR TITLE
Table extraction with Unstructured.io API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
-# Required for LLAMA PARSE
+# Required for table extraction with LLAMA PARSE API
 LLAMA_CLOUD_API_KEY=CHANGE_ME
 
-# OPEN AI is required for table cleaning via "LLM" method
+# Required for table extraction with UNSTRUCTURED.IO API
+UNSTRUCTURED_API_KEY=CHANGE_ME
+
+# Required for table cleaning via current "LLM" method
 OPENAI_API_KEY=CHANGE_ME
 
 # Required for LangChain tracing ("LangSmith")

--- a/configs/v0.yaml
+++ b/configs/v0.yaml
@@ -15,5 +15,6 @@ table_extraction:
       hi_res_model_name: "yolox"
       pdf_image_dpi: 300
 #    - type: LLamaParse
+#    - type: UnstructuredAPI
 
 # table_cleaning:

--- a/country_by_country/table_extraction/__init__.py
+++ b/country_by_country/table_extraction/__init__.py
@@ -24,6 +24,7 @@
 from .camelot_extractor import Camelot
 from .llama_parse_extractor import LlamaParseExtractor
 from .unstructured import Unstructured
+from .unstructured_api import UnstructuredAPI
 
 
 def from_config(config: dict) -> Camelot:
@@ -35,6 +36,8 @@ def from_config(config: dict) -> Camelot:
         return Camelot(**extractor_params)
     elif extractor_type == "Unstructured":
         return Unstructured(**extractor_params)
+    elif extractor_type == "UnstructuredAPI":
+        return UnstructuredAPI(**extractor_params)
     elif extractor_type == "LLamaParse":
         return LlamaParseExtractor(**extractor_params)
     return None

--- a/country_by_country/table_extraction/unstructured_api.py
+++ b/country_by_country/table_extraction/unstructured_api.py
@@ -1,0 +1,85 @@
+# MIT License
+#
+# Copyright (c) 2024 dataforgood
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Standard imports
+import logging
+import uuid
+
+# External imports
+import os
+from io import StringIO
+
+import pandas as pd
+from unstructured_client import UnstructuredClient
+from unstructured_client.models import shared
+from unstructured_client.models.errors import SDKError
+
+
+class UnstructuredAPI:
+    def __init__(self, **kwargs: dict) -> dict:
+        """
+        Builds a pdf page parser, looking for tables using
+        the unstructured.io api.
+        The kwargs given to the constructor are directly propagated
+        to the partition_pdf function.
+        You are free to define any parameter partition_pdf recognizes
+        """
+        self.kwargs = kwargs
+        self.type = "unstructured_api"
+
+    def __call__(self, pdf_filepath: str) -> dict:
+        logging.info("\nKicking off extraction stage...")
+        logging.info(f"Extraction type: {self.type}, with params: {self.kwargs}")
+
+        s = UnstructuredClient(api_key_auth=os.getenv('UNSTRUCTURED_API_KEY'))
+
+        with open(pdf_filepath, "rb") as f:
+        # Note that this currently only supports a single file
+            files=shared.Files(
+            content=f.read(),
+            file_name=pdf_filepath,
+	    )
+
+        req = shared.PartitionParameters(
+            files=files,
+            strategy='hi_res',
+            pdf_infer_table_structure='True',
+            **self.kwargs,
+        )
+
+        try:
+            resp = s.general.partition(req)
+
+            tables_list = [pd.read_html(StringIO(el["metadata"]["text_as_html"]))[0] for el in resp.elements if el["type"] == "Table"]
+
+            # Create asset
+            new_asset = {
+                "id": uuid.uuid4(),
+                "type": "unstructured_api",
+                "params": self.kwargs,
+                "tables": tables_list,
+            }
+
+            return new_asset
+        
+        except SDKError as e:
+           print(e)

--- a/country_by_country/table_extraction/unstructured_api.py
+++ b/country_by_country/table_extraction/unstructured_api.py
@@ -69,7 +69,7 @@ class UnstructuredAPI:
 
         try:
             resp = s.general.partition(req)
-        except SDKError as e:
+        except Exception as e:
             print(e)
         else:
             tables_list = [

--- a/country_by_country/table_extraction/unstructured_api.py
+++ b/country_by_country/table_extraction/unstructured_api.py
@@ -22,10 +22,10 @@
 
 # Standard imports
 import logging
-import uuid
 
 # External imports
 import os
+import uuid
 from io import StringIO
 
 import pandas as pd
@@ -50,26 +50,30 @@ class UnstructuredAPI:
         logging.info("\nKicking off extraction stage...")
         logging.info(f"Extraction type: {self.type}, with params: {self.kwargs}")
 
-        s = UnstructuredClient(api_key_auth=os.getenv('UNSTRUCTURED_API_KEY'))
+        s = UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"))
 
         with open(pdf_filepath, "rb") as f:
-        # Note that this currently only supports a single file
-            files=shared.Files(
-            content=f.read(),
-            file_name=pdf_filepath,
-	    )
+            # Note that this currently only supports a single file
+            files = shared.Files(
+                content=f.read(),
+                file_name=pdf_filepath,
+            )
 
         req = shared.PartitionParameters(
             files=files,
-            strategy='hi_res',
-            pdf_infer_table_structure='True',
+            strategy="hi_res",
+            pdf_infer_table_structure="True",
             **self.kwargs,
         )
 
         try:
             resp = s.general.partition(req)
 
-            tables_list = [pd.read_html(StringIO(el["metadata"]["text_as_html"]))[0] for el in resp.elements if el["type"] == "Table"]
+            tables_list = [
+                pd.read_html(StringIO(el["metadata"]["text_as_html"]))[0]
+                for el in resp.elements
+                if el["type"] == "Table"
+            ]
 
             # Create asset
             new_asset = {
@@ -80,6 +84,6 @@ class UnstructuredAPI:
             }
 
             return new_asset
-        
+
         except SDKError as e:
-           print(e)
+            print(e)

--- a/country_by_country/table_extraction/unstructured_api.py
+++ b/country_by_country/table_extraction/unstructured_api.py
@@ -32,7 +32,6 @@ from pathlib import Path
 import pandas as pd
 from unstructured_client import UnstructuredClient
 from unstructured_client.models import shared
-from unstructured_client.models.errors import SDKError
 
 
 class UnstructuredAPI:

--- a/country_by_country/table_extraction/unstructured_api.py
+++ b/country_by_country/table_extraction/unstructured_api.py
@@ -27,6 +27,7 @@ import logging
 import os
 import uuid
 from io import StringIO
+from pathlib import Path
 
 import pandas as pd
 from unstructured_client import UnstructuredClient
@@ -52,7 +53,7 @@ class UnstructuredAPI:
 
         s = UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"))
 
-        with open(pdf_filepath, "rb") as f:
+        with Path(pdf_filepath).open("rb") as f:
             # Note that this currently only supports a single file
             files = shared.Files(
                 content=f.read(),
@@ -68,7 +69,9 @@ class UnstructuredAPI:
 
         try:
             resp = s.general.partition(req)
-
+        except SDKError as e:
+            print(e)
+        else:
             tables_list = [
                 pd.read_html(StringIO(el["metadata"]["text_as_html"]))[0]
                 for el in resp.elements
@@ -84,6 +87,3 @@ class UnstructuredAPI:
             }
 
             return new_asset
-
-        except SDKError as e:
-            print(e)


### PR DESCRIPTION
This PR introduces a new table extraction option by integrating with Unstructured.io API.

Similarly as llama parse, an API key is required and unstructured.io offers a free tier (1000 free pages I think).

The end goal is to compare various parsing methodologies, self-hosted (Camelot, Unstructured), hosted (LLama parse, Unstructured.io API), and try various parameter values (ex: pdf_image_dpi for unstructured). The quality of parsing should have a huge impact on the end result.