### PR TITLE
Injection des CSV déjà extraits dans la pipeline

### DIFF
--- a/country_by_country/table_extraction/__init__.py
+++ b/country_by_country/table_extraction/__init__.py
@@ -22,6 +22,7 @@
 
 # Local imports
 from .camelot_extractor import Camelot
+from .from_csv import FromCSV
 from .llama_parse_extractor import LlamaParseExtractor
 from .unstructured import Unstructured
 from .unstructured_api import UnstructuredAPI
@@ -34,6 +35,8 @@ def from_config(config: dict) -> Camelot:
         extractor_params = config["params"]
     if extractor_type == "Camelot":
         return Camelot(**extractor_params)
+    elif extractor_type == "FromCSV":
+        return FromCSV(**extractor_params)
     elif extractor_type == "Unstructured":
         return Unstructured(**extractor_params)
     elif extractor_type == "UnstructuredAPI":

--- a/country_by_country/table_extraction/from_csv.py
+++ b/country_by_country/table_extraction/from_csv.py
@@ -53,7 +53,7 @@ class FromCSV:
         # Create asset
         new_asset = {
             "id": uuid.uuid4(),
-            "type": "camelot",
+            "type": "from_csv",
             "params": {"csv_directory": self.csv_directory},
             "tables": tables_list,
         }

--- a/country_by_country/table_extraction/from_csv.py
+++ b/country_by_country/table_extraction/from_csv.py
@@ -1,0 +1,63 @@
+# MIT License
+#
+# Copyright (c) 2024 dataforgood
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Standard imports
+import glob
+import logging
+from pathlib import Path
+import uuid
+
+# External imports
+import pandas as pd
+
+
+class FromCSV:
+    def __init__(self, csv_directory: str) -> None:
+        self.csv_directory = csv_directory
+
+    def __call__(self, pdf_filepath: str) -> dict:
+        """
+        Returns asset that contain:
+
+        """
+        # Build the path to the csv of the tables
+        # we expect the csv to be defined as
+        # - given a report /path/to/my_report.pdf
+        # Tables are searched for as
+        # - csv_directory/my_report_1.csv, csv_directory/my_report_2.csv,
+        # csv_directory/my_report_2.csv, ...
+        tables_list = []
+        report_basename = Path(pdf_filepath).stem.split("____")[0]
+
+        tables_files = glob.glob(f"{self.csv_directory}/{report_basename}*.csv")
+        tables_list = [pd.read_csv(f) for f in tables_files]
+        print(tables_list)
+
+        # Create asset
+        new_asset = {
+            "id": uuid.uuid4(),
+            "type": "camelot",
+            "params": {"csv_directory": self.csv_directory},
+            "tables": tables_list,
+        }
+
+        return new_asset

--- a/country_by_country/table_extraction/from_csv.py
+++ b/country_by_country/table_extraction/from_csv.py
@@ -22,9 +22,8 @@
 
 # Standard imports
 import glob
-import logging
-from pathlib import Path
 import uuid
+from pathlib import Path
 
 # External imports
 import pandas as pd

--- a/country_by_country/table_extraction/from_csv.py
+++ b/country_by_country/table_extraction/from_csv.py
@@ -50,7 +50,6 @@ class FromCSV:
 
         tables_files = glob.glob(f"{self.csv_directory}/{report_basename}*.csv")
         tables_list = [pd.read_csv(f) for f in tables_files]
-        print(tables_list)
 
         # Create asset
         new_asset = {

--- a/country_by_country/utils/utils.py
+++ b/country_by_country/utils/utils.py
@@ -48,7 +48,9 @@ def keep_pages(pdf_filepath: str, selected_pages: list[int]) -> str:
     # CSV to load
     pdf_stem = pathlib.Path(pdf_filepath).stem
     filename = tempfile.NamedTemporaryFile(
-        prefix=f"{pdf_stem}____", suffix=".pdf", delete=False
+        prefix=f"{pdf_stem}____",
+        suffix=".pdf",
+        delete=False,
     ).name
     print(f"filename {filename}")
     writer.write(filename)

--- a/country_by_country/utils/utils.py
+++ b/country_by_country/utils/utils.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 # Standard imports
+import pathlib
 import tempfile
 
 # External imports
@@ -39,7 +40,17 @@ def keep_pages(pdf_filepath: str, selected_pages: list[int]) -> str:
     for pi in selected_pages:
         writer.add_page(reader.pages[pi])
 
-    filename = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False).name
+    # We add the original pdf name without extension
+    # in the prefix of the temporary file
+    # in order to keep a trace of this name so that the next modules, from table
+    # extraction can make use of this name.
+    # For example, FromCSV makes use of this name to determine the name of the
+    # CSV to load
+    pdf_stem = pathlib.Path(pdf_filepath).stem
+    filename = tempfile.NamedTemporaryFile(
+        prefix=f"{pdf_stem}____", suffix=".pdf", delete=False
+    ).name
+    print(f"filename {filename}")
     writer.write(filename)
 
     return filename


### PR DESCRIPTION
Avec cette PR, on peut injecter dans la pipeline des tableaux CSV déjà extrait, par exemple par extracttable. 

On l'ajoute dans le fichier de config par :

```
table_extraction:
  - type: FromCSV
    params:
      csv_directory: "./data/table_extract/labels/"
```

Le principe, c'est que pour chaque rapport `titi_toto.pdf` , on va chercher dans les csv qui matchent avec : `csv_directory/titi_toto*.csv` et on les charge.

Il y a un petit travail à faire sur les extractions de Giulia et Kane : les extractions de extracttable de toutes les tables sont dans un même CSV, il faut les séparer en plusieurs CSV .

Par exemple, je joins à la PR, les extractions pour Applus_2021.pdf . Le rapport est joint aussi , il porte le même nom "Applus_2021.pdf" qu'on retrouve dans le CSV.

L'étape de `pagefilter` doit toujours être spécifiée. On peut prendre `CopyAsIs` si on veut (puisquie les tables sont extraites des CSV de toute façon, peu importe si le filtrage fait quelque chose) mais on peut aussi appliquer les autres filtres. Attention , si on utilise `FromFilename`, il faudra bien s'assurer que les noms des CSVs contiennent comme préfixe le nom complet du rapport, donc comprenant aussi l enuméro de page.


[Applus_2021.pdf](https://github.com/dataforgoodfr/12_taxobservatory/files/14800914/Applus_2021.pdf)

[Applus_2021_1.csv](https://github.com/dataforgoodfr/12_taxobservatory/files/14800907/Applus_2021_1.csv)
[Applus_2021_2.csv](https://github.com/dataforgoodfr/12_taxobservatory/files/14800908/Applus_2021_2.csv)
[Applus_2021_3.csv](https://github.com/dataforgoodfr/12_taxobservatory/files/14800909/Applus_2021_3.csv)
