### PR TITLE
fix table cleaners construction

### DIFF
--- a/country_by_country/processor.py
+++ b/country_by_country/processor.py
@@ -23,9 +23,8 @@
 # Standard imports
 import logging
 
-from . import pagefilter, table_extraction
-
 # Local imports
+from . import pagefilter, table_cleaning, table_extraction
 from .utils.utils import keep_pages
 
 
@@ -50,7 +49,7 @@ class ReportProcessor:
             if "table_cleaning" in config:
                 table_cleaners = config["table_cleaning"]
                 self.table_cleaners = [
-                    self.table_cleaning.from_config(name) for name in table_cleaners
+                    table_cleaning.from_config(name) for name in table_cleaners
                 ]
 
     def process(self, pdf_filepath: str) -> dict:


### PR DESCRIPTION
There was a syntax error in the table cleaning construction in the constructor of the ReportProcessor object;

This PR fixes it. 