### PR TITLE
Eval app bug fix and simplification of table extraction from CSV

### DIFF
--- a/country_by_country/table_extraction/from_csv.py
+++ b/country_by_country/table_extraction/from_csv.py
@@ -38,15 +38,10 @@ class FromCSV:
         Returns asset that contain:
 
         """
-        # Build the path to the csv of the tables
-        # we expect the csv to be defined as
-        # - given a report /path/to/my_report.pdf
-        # Tables are searched for as
-        # - csv_directory/my_report_1.csv, csv_directory/my_report_2.csv,
-        # csv_directory/my_report_2.csv, ...
-        tables_list = []
-        report_basename = Path(pdf_filepath).stem.split("____")[0]
-
+        # Load the tables from matching csv files
+        # Given a report /path/to/{company_name}_{year}*.pdf
+        # Tables are searched in /csv_directory/{company_name}_{year}*.csv
+        report_basename = "_".join(Path(pdf_filepath).stem.split("_")[0:2])
         tables_files = glob.glob(f"{self.csv_directory}/{report_basename}*.csv")
         tables_list = [pd.read_csv(f) for f in tables_files]
 

--- a/eval/eval_app.py
+++ b/eval/eval_app.py
@@ -66,11 +66,10 @@ def main(ref_data_file: str = None) -> None:
         try:
             ss.ref_uploaded = pd.read_csv(ref_data_file)
         except Exception as e:
-            if ref_data_file is None:
-                msg= "REF data file not specified."
-            else:
-                msg=e
-            st.warning(f"REF data file not loaded. Continue without or fix the below error.\n\n{msg}")
+            msg = "REF data file not specified." if ref_data_file is None else e
+            st.warning(
+                f"REF data file not loaded. Continue without or fix the below error.\n\n{msg}"
+            )
             ss.ref_uploaded = None
 
     # Display title

--- a/eval/eval_app.py
+++ b/eval/eval_app.py
@@ -68,7 +68,7 @@ def main(ref_data_file: str = None) -> None:
         except Exception as e:
             msg = "REF data file not specified." if ref_data_file is None else e
             st.warning(
-                f"REF data file not loaded. Continue without or fix the below error.\n\n{msg}"
+                f"REF data file not loaded. Continue without or fix the below error.\n\n{msg}",
             )
             ss.ref_uploaded = None
 

--- a/eval/eval_app.py
+++ b/eval/eval_app.py
@@ -65,11 +65,12 @@ def main(ref_data_file: str = None) -> None:
     if "ref_uploaded" not in ss:
         try:
             ss.ref_uploaded = pd.read_csv(ref_data_file)
-        except Exception:
-            st.warning(
-                """REF data not found. Continue without or set the constant ref_data_file /
-                to the full path of the data_step2_before-currency-unit.csv file.""",
-            )
+        except Exception as e:
+            if ref_data_file is None:
+                msg= "REF data file not specified."
+            else:
+                msg=e
+            st.warning(f"REF data file not loaded. Continue without or fix the below error.\n\n{msg}")
             ss.ref_uploaded = None
 
     # Display title
@@ -184,7 +185,7 @@ def process_pdf(pdf_file: str, asset_dict: dict) -> None:
                     "container": {
                         "padding": "0!important",
                         "margin": "0!important",
-                        "background-color": "#D3D3D3",
+                        "background-color": "#EFF2F6",
                     },
                     "nav-item": {
                         "max-width": "100px",
@@ -194,10 +195,10 @@ def process_pdf(pdf_file: str, asset_dict: dict) -> None:
                     "icon": {"font-size": "0px"},
                 },
             )
-            ss.selected_idx = dfs_str.index(selected)
+            selected_idx = dfs_str.index(selected)
 
             # Display table
-            df = dfs[ss.selected_idx]
+            df = dfs[selected_idx]
 
             # Check if values in table are in tables of reference extraction
             refvalues = []


### PR DESCRIPTION
This PR solves 2 main problems:

**Streamlit eval app**
* When the user selected another table, it didn't always work.
* This PR should resolve the issue.

**Table extraction from CSV**
* The CSV was required to contain exactly the same name as the PDF. I found this constrained us a bit too much, as the CSV from extracttable we got from Giulia & Kane don't follow this pattern.
* Now, to be considered a match, the CSV is only required to have the same prefix as the PDF, that is {company_name}_{year}.