### PR TITLE
move the keep_pages to Page1; allow dynamic page selection

### DIFF
--- a/app/PDF visualisation.py
+++ b/app/PDF visualisation.py
@@ -5,9 +5,9 @@ import tempfile
 import streamlit as st
 import yaml
 from utils import get_pdf_iframe
+from pypdf import PdfReader
 
 from country_by_country.processor import ReportProcessor
-from country_by_country.utils.utils import keep_pages
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
 
@@ -94,15 +94,8 @@ if "original_pdf" in st.session_state:
         if len(assets["pagefilter"]["selected_pages"]) == 0:
             # No page has been automatically selected by the page filter
             # Hence, we display the full pdf, letting the user select the pages
-            st.session_state["pdf_before_page_validation"] = st.session_state[
-                "original_pdf"
-            ].name
-        else:
-            # Otherwise, we keep only the pages selected by the page filter
-            st.session_state["pdf_before_page_validation"] = keep_pages(
-                st.session_state["original_pdf"].name,
-                assets["pagefilter"]["selected_pages"],
-            )
-            assets["pagefilter"]["selected_pages"] = []
+            pdfreader = PdfReader(st.session_state["original_pdf"])
+            number_pages = len(PdfReader(st.session_state["original_pdf"]).pages)
+            assets["pagefilter"]["selected_pages"] = list(range(number_pages))
         st.session_state["assets"] = assets
         st.switch_page("pages/1_Selected_Pages.py")

--- a/app/pages/1_Selected_Pages.py
+++ b/app/pages/1_Selected_Pages.py
@@ -4,6 +4,7 @@ from country_by_country.utils.utils import keep_pages
 from pypdf import PdfReader
 
 import sys
+import copy
 import logging
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
@@ -17,45 +18,46 @@ st.subheader(
 if "original_pdf" in st.session_state:
 
     col1, col2 = st.columns([1, 1])
-    with col1:
-        st.markdown(
-            get_pdf_iframe(st.session_state["pdf_before_page_validation"]),
-            unsafe_allow_html=True,
-        )
 
-    with col2, st.form(key="selected_pages_form"):
+    with col2:
+        # Display the page selector on the right column
         pdfreader = PdfReader(st.session_state["original_pdf"])
-        number_pages = (
-            len(PdfReader(st.session_state["pdf_before_page_validation"]).pages) + 1
-        )  # Make the index start to 1
-        st.session_state["assets"]["pagefilter"]["selected_pages"] = st.multiselect(
+        number_pages = len(PdfReader(st.session_state["original_pdf"]).pages)
+        logging.info("got the assets : " + str(st.session_state["assets"]))
+        selected_pages = st.multiselect(
             "Which page of the following pdf contains the table you want to extract ?",
-            list(range(1, number_pages)),
+            list(range(1, number_pages + 1)),
             placeholder="Select a page number",
-            default=(
-                st.session_state["assets"]["pagefilter"]["selected_pages"]
-                if "assets" in st.session_state
-                else None
-            ),
+            default=[
+                i + 1
+                for i in st.session_state["assets"]["pagefilter"]["selected_pages"]
+            ],
         )
-        # TODO : add a new button in order to use original pdf if the table was not found
-        submitted = st.form_submit_button(
+        submitted = st.button(
             label="Validate your selected pages",
             on_click=set_validate,
             args=("validate_selected_pages",),
         )
 
-    st.session_state["pdf_after_page_validation"] = keep_pages(
-        st.session_state["pdf_before_page_validation"],
-        [
-            item - 1
-            for item in st.session_state["assets"]["pagefilter"]["selected_pages"]
-        ],
+    selected_pages = sorted(selected_pages)
+    logging.info("Filtering the pdf with pages : " + str(selected_pages))
+    st.session_state["pdf_before_page_validation"] = keep_pages(
+        st.session_state["original_pdf"].name,
+        [i - 1 for i in selected_pages],
     )
 
-    if (
-        len(st.session_state["assets"]["pagefilter"]["selected_pages"]) != 0
-        and "first_time_selected" not in st.session_state
-    ):
-        st.session_state["first_time_selected"] = False
+    with col1:
+        # Display the filtered pdf on the left column
+        st.markdown(
+            get_pdf_iframe(st.session_state["pdf_before_page_validation"]),
+            unsafe_allow_html=True,
+        )
+
+    if submitted:
+        # Once the submission button is clicked, we commit the selected pages
+        # The next pages will work with the pdf_after_page_validation
+        st.session_state["pdf_after_page_validation"] = keep_pages(
+            st.session_state["original_pdf"].name,
+            [i - 1 for i in selected_pages],
+        )
         st.switch_page("pages/2_Headers.py")

--- a/app/pages/1_Selected_Pages.py
+++ b/app/pages/1_Selected_Pages.py
@@ -56,6 +56,7 @@ if "original_pdf" in st.session_state:
     if submitted:
         # Once the submission button is clicked, we commit the selected pages
         # The next pages will work with the pdf_after_page_validation
+        st.session_state["assets"]["pagefilter"]["selected_pages"] = selected_pages
         st.session_state["pdf_after_page_validation"] = keep_pages(
             st.session_state["original_pdf"].name,
             [i - 1 for i in selected_pages],


### PR DESCRIPTION
In this PR, the page selection logic is slightly changed: 

- page selection per se (hence keep_pages) is ran in `1_Selected_Pages.py` not in the first page 
- the default of the multiselect is either the pages selected by the random forest if any or all the pages of the pdf if no pages has been selected
- every time the multiselect is changed, the pdf displayed in the iframe is refreshed allowing to dynamically add/remove pages
- the temporary pdf being displayed is `st.session_state["pdf_before_page_validation"]` and this PDF is changed every time the multiselect options are changed
- the sub-pdf to be processed by the next stages is produced once the button is clicked, commiting the page selection to the pdf `st.session_state["pdf_after_page_validation"]`


So the logic is that it is the responsibility of the page `1_Selected_Pages.py` to iterate over `keep_pages` based on the options selected in the multiselect and, once the user is happy with the selection, the selection is definitely applied to produce `st.session_state["pdf_before_page_validation"]`  processed by the next stage. 