### PR TITLE
Checkbox pour transposer la table dans la page 3 Clean Headers

### DIFF
--- a/app/pages/3_Clean_Headers.py
+++ b/app/pages/3_Clean_Headers.py
@@ -24,6 +24,14 @@ def set_headers(algorithm_name: str) -> None:
             )
 
 
+def transpose_table(algorithm_name: str) -> None:
+    """
+    This function allows to transpose the table.
+    Sometimes, the CbCR contains tables where the juridictions are in rows and not in columns.
+    """
+    st.session_state.tables[algorithm_name] = st.session_state.tables[algorithm_name].T
+
+
 header_list = [
     keep,
     "jurisdiction",
@@ -81,6 +89,12 @@ if (
             "Table shape :"
             + str(st.session_state.tables[st.session_state["algorithm_name"]].shape)
         )
+        transpose = st.checkbox(
+            "Transpose the table",
+            on_change=transpose_table,
+            args=(st.session_state["algorithm_name"],),
+        )
+
         with st.form(key="my_form"):
             for header in st.session_state.tables[
                 st.session_state["algorithm_name"]

--- a/app/pages/3_Clean_Headers.py
+++ b/app/pages/3_Clean_Headers.py
@@ -113,3 +113,11 @@ if (
 
             if submitted:
                 st.switch_page("pages/4_Clean_Tables.py")
+
+    df = st.data_editor(
+        st.session_state.tables[st.session_state["algorithm_name"]],
+        num_rows="dynamic",
+        width=900,
+        height=900,
+        disabled=True,
+    )


### PR DESCRIPTION
Permet de résoudre #54 

Ajoute également une visualisation des tables sur la page `3_Clean_Headers` , ce qui permet en particulier de voir toute la table ainsi que l'effet de la transposition.


close #54 