### PR TITLE
Ajout d'un bouton de reset pour pouvoir revenir à la page d'accueil 

### DIFF
--- a/app/menu.py
+++ b/app/menu.py
@@ -7,7 +7,7 @@ def display_pages_menu() -> None:
         st.markdown("Click the button below to reset the app")
         if st.button("Reset", type="primary"):
             st.session_state.clear()
-            st.switch_page("PDF_visualisation.py")
+            st.switch_page("index.py")
 
         st.markdown("# Pipeline steps")
         st.page_link("pages/0_Import_File.py", label="Upload PDF")

--- a/app/menu.py
+++ b/app/menu.py
@@ -2,8 +2,16 @@ import streamlit as st
 
 
 def display_pages_menu() -> None:
-    st.sidebar.page_link("pages/0_Import_File.py", label="Upload PDF")
-    st.sidebar.page_link("pages/1_Selected_Pages.py", label="Pages selection")
-    st.sidebar.page_link("pages/2_Merge_Tables.py", label="Merge tables")
-    st.sidebar.page_link("pages/3_Clean_Headers.py", label="Headers setup")
-    st.sidebar.page_link("pages/4_Clean_Tables.py", label="Tables customization")
+    with st.sidebar:
+        st.markdown("# Reset")
+        st.markdown("Click the button below to reset the app")
+        if st.button("Reset", type="primary"):
+            st.session_state.clear()
+            st.switch_page("PDF_visualisation.py")
+
+        st.markdown("# Pipeline steps")
+        st.page_link("pages/0_Import_File.py", label="Upload PDF")
+        st.page_link("pages/1_Selected_Pages.py", label="Pages selection")
+        st.page_link("pages/2_Merge_Tables.py", label="Merge tables")
+        st.page_link("pages/3_Clean_Headers.py", label="Headers setup")
+        st.page_link("pages/4_Clean_Tables.py", label="Tables customization")

--- a/app/pages/0_Import_File.py
+++ b/app/pages/0_Import_File.py
@@ -22,6 +22,15 @@ display_pages_menu()
 mytmpfile = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
 
 with st.sidebar:
+
+    st.markdown("# Reset")
+    st.markdown("Click the button below to reset the app")
+    if st.button("Reset", type="primary"):
+        st.session_state.clear()
+        st.switch_page("PDF_visualisation.py")
+
+    st.markdown("# Configuration")
+
     original_pdf = st.file_uploader(
         "Upload a pdf document containing financial table : ",
     )

--- a/app/pages/0_Import_File.py
+++ b/app/pages/0_Import_File.py
@@ -23,12 +23,6 @@ mytmpfile = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
 
 with st.sidebar:
 
-    st.markdown("# Reset")
-    st.markdown("Click the button below to reset the app")
-    if st.button("Reset", type="primary"):
-        st.session_state.clear()
-        st.switch_page("PDF_visualisation.py")
-
     st.markdown("# Configuration")
 
     original_pdf = st.file_uploader(


### PR DESCRIPTION
Cette PR ajoute un bouton "reset" dans la sidebar pour facilement revenir à l'accueil avec l'état réinitialisé et pouvoir recommencer le process complet sans avoir à cliquer  sur le premier lien + rafraichir la page. 

J'en ai profité pour un ajouté des titres de section "Makdown" dans la barre pour que ce soit un peu plus joli et différentiable. 

![image](https://github.com/dataforgoodfr/12_taxobservatory/assets/1128418/8a88f913-6f23-4ea7-81d3-374d4fca7b18)


![image](https://github.com/dataforgoodfr/12_taxobservatory/assets/1128418/3eb3a781-5761-49ea-9177-335860252f99)
