### PR TITLE
streamlit: add subsections for the pdf/pipeline config

### DIFF
--- a/app/pages/0_Import_File.py
+++ b/app/pages/0_Import_File.py
@@ -25,6 +25,7 @@ with st.sidebar:
 
     st.markdown("# Configuration")
 
+    st.markdown("## PDF Report to process")
     original_pdf = st.file_uploader(
         "Upload a pdf document containing financial table : ",
     )
@@ -39,6 +40,7 @@ with st.sidebar:
             "Already loaded file : " + st.session_state["original_pdf_name"],
         )
 
+    st.markdown("## Pipeline configuration")
     loaded_config = st.file_uploader(
         "Upload a config if the default config doesn't suit you :",
     )


### PR DESCRIPTION
Une toute PR pour, je trouve, mieux séparer visuellement la configuration du pipeline de l'upload du PDF;

![image](https://github.com/dataforgoodfr/12_taxobservatory/assets/1128418/e9b3b788-5079-4573-9263-ae9db0ffd3a0)
