### PR TITLE
adapt eval app PDF download to new HF repo structure

### DIFF
--- a/eval/eval_app.py
+++ b/eval/eval_app.py
@@ -233,7 +233,7 @@ def process_pdf(pdf_file: str, asset_dict: dict) -> None:
         if not ss.pdf_downloaded:
             ss["pdf_downloaded"] = hf_hub_download(
                 repo_id="DataForGood/taxobservatory_data",
-                filename=ss.pdf_selected,
+                filename=f"pdf/{ss.pdf_selected}",
                 repo_type="dataset",
             )
 


### PR DESCRIPTION
Corrects the failed PDF download from the HF dataset due to the new structure